### PR TITLE
feat(newsletter): N2 opt-in honnête + relance in-app + attribution

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,6 +30,7 @@ import {
 import { Button, buttonVariants } from "@/components/ui/button";
 import { JournalStatsCard } from "@/components/app/JournalStatsCard";
 import { NewsletterSignupCard } from "@/components/app/NewsletterSignupCard";
+import { ReturnWelcomeCard } from "@/components/app/ReturnWelcomeCard";
 
 const CHALLENGE_DURATION = 30;
 const NEWSLETTER_KEY = "gratitudeNewsletter";
@@ -44,7 +45,9 @@ export default function GratitudeChallengePage() {
   const [currentQuote, setCurrentQuote] = React.useState<Quote | null>(null);
   const [isResetDialogOpen, setIsResetDialogOpen] = React.useState(false);
   const badgesCardRef = React.useRef<HTMLDivElement>(null);
+  const gratitudeCardRef = React.useRef<HTMLDivElement>(null);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
+  const [returnDismissed, setReturnDismissed] = React.useState(false);
   const [newsletter, setNewsletter] = React.useState<{ subscribed: boolean; dismissed: boolean }>({
     subscribed: false,
     dismissed: false,
@@ -386,6 +389,24 @@ export default function GratitudeChallengePage() {
   const streakText = `${state.streak} ${t(state.streak === 1 ? 'daySingular' : 'daysPlural')}`;
   const isChallengeComplete = state.entries.length >= CHALLENGE_DURATION;
 
+  // Relance in-app : jours pleins écoulés depuis la dernière entrée.
+  const daysSinceLastEntry = state.lastEntryDate
+    ? Math.floor(
+        (new Date(new Date().toDateString()).getTime() -
+          new Date(new Date(state.lastEntryDate).toDateString()).getTime()) /
+          86400000
+      )
+    : 0;
+  // S'affiche au retour après ≥ 2 jours d'absence, en cours de défi, une fois par session.
+  const showReturnWelcome =
+    !returnDismissed &&
+    state.entries.length >= 1 &&
+    !isChallengeComplete &&
+    daysSinceLastEntry >= 2;
+
+  const handleResumeChallenge = () =>
+    gratitudeCardRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+
   return (
     <main className="container mx-auto p-4 md:p-8 flex-grow">
         <Header onReset={() => setIsResetDialogOpen(true)} onShare={handleShare} onExport={handleExportData} onImport={handleImportClick} />
@@ -398,8 +419,18 @@ export default function GratitudeChallengePage() {
             data-testid="file-input"
         />
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mt-6">
-            <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.1 }} className="lg:col-span-2 md:row-span-2">
-                <GratitudeCard 
+            {showReturnWelcome && (
+                <div className="lg:col-span-3">
+                    <ReturnWelcomeCard
+                        days={daysSinceLastEntry}
+                        day={state.currentDay}
+                        onResume={handleResumeChallenge}
+                        onDismiss={() => setReturnDismissed(true)}
+                    />
+                </div>
+            )}
+            <motion.div ref={gratitudeCardRef} initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.1 }} className="lg:col-span-2 md:row-span-2">
+                <GratitudeCard
                     prompt={currentPrompt}
                     day={lastEntry ? lastEntry.day : state.currentDay}
                     isSubmittedToday={isTodayEntrySubmitted}

--- a/src/components/app/Footer.tsx
+++ b/src/components/app/Footer.tsx
@@ -33,7 +33,7 @@ export function Footer() {
           {t('footerText')}
         </p>
         <a
-          href="https://www.greg-ggt.com/#/portal/signup"
+          href="https://www.greg-ggt.com/#/portal/signup?ref=defi"
           target="_blank"
           rel="noopener noreferrer"
           className="text-sm text-primary hover:underline mb-4 md:mb-0 md:mx-4"

--- a/src/components/app/ReturnWelcomeCard.tsx
+++ b/src/components/app/ReturnWelcomeCard.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import * as React from "react";
+import { motion } from "framer-motion";
+import { HeartHandshake, X } from "lucide-react";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useLanguage } from "@/components/app/LanguageProvider";
+
+interface ReturnWelcomeCardProps {
+  /** Nombre de jours écoulés depuis la dernière entrée. */
+  days: number;
+  /** Jour de défi à reprendre. */
+  day: number;
+  /** Action « Reprendre » (ex. focus/scroll vers la carte de saisie). */
+  onResume?: () => void;
+  /** Fermeture pour la session en cours. */
+  onDismiss?: () => void;
+}
+
+/**
+ * Carte de relance affichée au retour après une absence, pendant le défi.
+ * Ton accueillant, zéro culpabilisation : on n'agite pas la série cassée,
+ * on invite simplement à reprendre. Aucune dépendance externe (lit l'état local).
+ */
+export function ReturnWelcomeCard({ days, day, onResume, onDismiss }: ReturnWelcomeCardProps) {
+  const { t } = useLanguage();
+
+  const description = t("returnWelcomeDescription")
+    .replace("{days}", String(days))
+    .replace("{day}", String(day));
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4 }}
+    >
+      <Card className="relative border-primary/40 bg-primary/5">
+        {onDismiss && (
+          <button
+            type="button"
+            onClick={onDismiss}
+            aria-label={t("returnWelcomeDismiss")}
+            className="absolute right-3 top-3 text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-primary">
+            <HeartHandshake className="h-5 w-5" />
+            <span>{t("returnWelcomeTitle")}</span>
+          </CardTitle>
+          <CardDescription>{description}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button onClick={onResume}>{t("returnWelcomeCta")}</Button>
+        </CardContent>
+      </Card>
+    </motion.div>
+  );
+}

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -96,9 +96,9 @@
     "entryUpdatedTitle": "Entry Updated",
     "entryUpdatedDescription": "Your gratitude entry has been successfully updated.",
     "newsletterTitle": "Keep the momentum",
-    "newsletterDescription": "Get a gentle daily nudge and my tools for cultivating gratitude, straight to your inbox.",
+    "newsletterDescription": "One email a month: my well-being tools applied like a game, plus behind-the-scenes of the app to come. Reply anytime — I read everything.",
     "newsletterCompletionTitle": "Nicely done — 30 days!",
-    "newsletterCompletionDescription": "You did the hard part. Keep going with the newsletter: my well-being tools and news about the upcoming app.",
+    "newsletterCompletionDescription": "You did the hard part. The newsletter takes over: one email a month, my well-being tools and news about the upcoming app. Reply to me directly.",
     "newsletterEmailPlaceholder": "you@email.com",
     "newsletterCta": "Subscribe",
     "newsletterSubmitting": "One moment…",
@@ -110,5 +110,9 @@
     "newsletterErrorDescription": "Sign-up didn't go through. Please try again in a moment.",
     "newsletterInvalidEmail": "That email address looks invalid.",
     "newsletterDismiss": "Close",
-    "footerNewsletter": "Newsletter"
+    "footerNewsletter": "Newsletter",
+    "returnWelcomeTitle": "Good to see you back",
+    "returnWelcomeDescription": "It's been {days} days. No pressure on the streak — just pick up at day {day}, one entry is enough.",
+    "returnWelcomeCta": "Resume",
+    "returnWelcomeDismiss": "Close"
 }

--- a/src/lib/locales/fr.json
+++ b/src/lib/locales/fr.json
@@ -96,9 +96,9 @@
     "entryUpdatedTitle": "Entrée mise à jour",
     "entryUpdatedDescription": "Votre entrée de gratitude a été mise à jour avec succès.",
     "newsletterTitle": "Garde l'élan",
-    "newsletterDescription": "Reçois un petit rappel quotidien et mes outils pour cultiver la gratitude, directement par e-mail.",
+    "newsletterDescription": "Un e-mail par mois : mes outils bien-être appliqués comme un jeu, et les coulisses de l'app à venir. Réponds-moi, je lis tout.",
     "newsletterCompletionTitle": "Bravo, 30 jours tenus !",
-    "newsletterCompletionDescription": "Tu as fait le plus dur. Continue avec la newsletter : mes outils bien-être et les nouveautés de l'app à venir.",
+    "newsletterCompletionDescription": "Tu as fait le plus dur. La newsletter prend le relais : un e-mail par mois, mes outils bien-être et les nouveautés de l'app à venir. Réponds-moi directement.",
     "newsletterEmailPlaceholder": "ton@email.com",
     "newsletterCta": "Je m'abonne",
     "newsletterSubmitting": "Un instant…",
@@ -110,5 +110,9 @@
     "newsletterErrorDescription": "L'inscription n'a pas abouti. Réessaie dans un instant.",
     "newsletterInvalidEmail": "Cette adresse e-mail semble invalide.",
     "newsletterDismiss": "Fermer",
-    "footerNewsletter": "Newsletter"
+    "footerNewsletter": "Newsletter",
+    "returnWelcomeTitle": "Content de te revoir",
+    "returnWelcomeDescription": "Ça fait {days} jours. Pas de pression pour la série — reprends simplement au jour {day}, une entrée suffit.",
+    "returnWelcomeCta": "Reprendre",
+    "returnWelcomeDismiss": "Fermer"
 }

--- a/src/lib/newsletter.ts
+++ b/src/lib/newsletter.ts
@@ -45,7 +45,10 @@ export async function subscribeToNewsletter(
   const body: Record<string, unknown> = {
     email,
     emailType: "subscribe",
-    labels: [],
+    // Attribution best-effort : tague la source pour mesurer l'apport du défi
+    // dans Ghost Admin. Ghost peut ignorer ce champ sur l'endpoint public
+    // (à vérifier sur une inscription test) ; aucun effet négatif s'il le strip.
+    labels: ["défi"],
     name: null,
   };
   if (integrityToken) body.integrityToken = integrityToken;


### PR DESCRIPTION
- copy opt-in (inline + completion) aligné sur le welcome (≈1 e-mail/mois, jeu x bien-etre) au lieu du faux 'rappel quotidien' inexistant (FR/EN)
- ReturnWelcomeCard : relance au retour apres >=2 j d'absence, sans culpabilisation
- attribution : label 'défi' (best-effort) + ?ref=defi sur le lien Footer
- aucune nouvelle erreur tsc