### PR TITLE
feat(completion): écran J30 célébratoire + partage parcours (N1)

### DIFF
--- a/src/app/journal/page.tsx
+++ b/src/app/journal/page.tsx
@@ -121,10 +121,10 @@ export default function JournalPage() {
             src: url('https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,200..900;1,7..72,200..900&display=swap');
           }
         `;
-        const dataUrl = await toPng(imagePreviewRef.current, { 
-            cacheBust: true, 
+        const dataUrl = await toPng(imagePreviewRef.current, {
+            cacheBust: true,
             pixelRatio: 2,
-            fontEmbedCss: fontEmbedCss
+            fontEmbedCSS: fontEmbedCss
         });
         
         const blob = await (await fetch(dataUrl)).blob();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -178,18 +178,22 @@ export default function GratitudeChallengePage() {
 
   // Débloque le badge "partage" au premier partage réussi (écran J30).
   const handleUnlockShareBadge = () => {
-    setState((prev) => {
-      if (!prev || prev.unlockedBadges.includes("share-1")) return prev;
-      const shareBadge = BADGES.find((b) => b.id === "share-1");
-      if (!shareBadge) return prev;
-      toast({
-        title: t("badgeUnlocked"),
-        description: t("badgeUnlockedDescription").replace(
-          "{badgeName}",
-          t(shareBadge.nameKey)
-        ),
-      });
-      return { ...prev, unlockedBadges: [...prev.unlockedBadges, shareBadge.id] };
+    if (!state || state.unlockedBadges.includes("share-1")) return;
+    const shareBadge = BADGES.find((b) => b.id === "share-1");
+    if (!shareBadge) return;
+    // setState updater pur : pas d'effet de bord (toast) dedans, sinon React
+    // râle « Cannot update a component while rendering a different component ».
+    setState((prev) =>
+      prev && !prev.unlockedBadges.includes(shareBadge.id)
+        ? { ...prev, unlockedBadges: [...prev.unlockedBadges, shareBadge.id] }
+        : prev
+    );
+    toast({
+      title: t("badgeUnlocked"),
+      description: t("badgeUnlockedDescription").replace(
+        "{badgeName}",
+        t(shareBadge.nameKey)
+      ),
     });
   };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,6 +31,7 @@ import { Button, buttonVariants } from "@/components/ui/button";
 import { JournalStatsCard } from "@/components/app/JournalStatsCard";
 import { NewsletterSignupCard } from "@/components/app/NewsletterSignupCard";
 import { ReturnWelcomeCard } from "@/components/app/ReturnWelcomeCard";
+import { CompletionScreen } from "@/components/app/CompletionScreen";
 
 const CHALLENGE_DURATION = 30;
 const NEWSLETTER_KEY = "gratitudeNewsletter";
@@ -48,6 +49,9 @@ export default function GratitudeChallengePage() {
   const gratitudeCardRef = React.useRef<HTMLDivElement>(null);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
   const [returnDismissed, setReturnDismissed] = React.useState(false);
+  // À J30, on bascule sur l'écran de complétion ; ce toggle permet de revenir
+  // au tableau de bord classique (échappatoire), sans perdre la célébration.
+  const [showDashboard, setShowDashboard] = React.useState(false);
   const [newsletter, setNewsletter] = React.useState<{ subscribed: boolean; dismissed: boolean }>({
     subscribed: false,
     dismissed: false,
@@ -170,6 +174,23 @@ export default function GratitudeChallengePage() {
   const handleNewsletterDismiss = () => {
     persistNewsletter({ ...newsletter, dismissed: true });
     setHideNewsletter(true);
+  };
+
+  // Débloque le badge "partage" au premier partage réussi (écran J30).
+  const handleUnlockShareBadge = () => {
+    setState((prev) => {
+      if (!prev || prev.unlockedBadges.includes("share-1")) return prev;
+      const shareBadge = BADGES.find((b) => b.id === "share-1");
+      if (!shareBadge) return prev;
+      toast({
+        title: t("badgeUnlocked"),
+        description: t("badgeUnlockedDescription").replace(
+          "{badgeName}",
+          t(shareBadge.nameKey)
+        ),
+      });
+      return { ...prev, unlockedBadges: [...prev.unlockedBadges, shareBadge.id] };
+    });
   };
 
   const handleAddEntry = (text: string, prompt: string) => {
@@ -418,6 +439,17 @@ export default function GratitudeChallengePage() {
             className="hidden"
             data-testid="file-input"
         />
+        {isChallengeComplete && !showDashboard ? (
+        <div className="mt-6">
+            <CompletionScreen
+                entries={state.entries}
+                showNewsletter={!hideNewsletter}
+                onNewsletterSubscribed={handleNewsletterSubscribed}
+                onShareBadgeUnlock={handleUnlockShareBadge}
+                onBackToDashboard={() => setShowDashboard(true)}
+            />
+        </div>
+        ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mt-6">
             {showReturnWelcome && (
                 <div className="lg:col-span-3">
@@ -477,6 +509,7 @@ export default function GratitudeChallengePage() {
                 {currentQuote && <QuoteCard quote={currentQuote.text} author={currentQuote.author} onNewQuote={handleNewQuote}/>}
             </motion.div>
         </div>
+        )}
         <AlertDialog open={isResetDialogOpen} onOpenChange={setIsResetDialogOpen}>
             <AlertDialogContent>
                 <AlertDialogHeader>

--- a/src/components/app/CompletionScreen.tsx
+++ b/src/components/app/CompletionScreen.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { toPng } from "html-to-image";
+import { Crown, Share2, BookOpen, LayoutDashboard } from "lucide-react";
+
+import type { GratitudeEntry } from "@/lib/types";
+import { BADGES } from "@/lib/data";
+import { computeLongestStreak } from "@/lib/streak";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { useLanguage } from "@/components/app/LanguageProvider";
+import { useToast } from "@/hooks/use-toast";
+import { NewsletterSignupCard } from "@/components/app/NewsletterSignupCard";
+import { ShareJourneyCard } from "@/components/app/ShareJourneyCard";
+
+const CHALLENGE_DURATION = 30;
+
+interface CompletionScreenProps {
+  entries: GratitudeEntry[];
+  /** Mémorise l'abonnement (gate au prochain montage). */
+  onNewsletterSubscribed: () => void;
+  /** Affiche encore la carte newsletter ? (false si déjà abonné·e/fermée). */
+  showNewsletter: boolean;
+  /** Débloque le badge "partage" au premier partage réussi. */
+  onShareBadgeUnlock: () => void;
+  /** Échappatoire : revenir au tableau de bord classique. */
+  onBackToDashboard: () => void;
+}
+
+const fadeUp = {
+  initial: { opacity: 0, y: 16 },
+  animate: { opacity: 1, y: 0 },
+};
+
+export function CompletionScreen({
+  entries,
+  onNewsletterSubscribed,
+  showNewsletter,
+  onShareBadgeUnlock,
+  onBackToDashboard,
+}: CompletionScreenProps) {
+  const { t } = useLanguage();
+  const { toast } = useToast();
+
+  const entriesCount = entries.length;
+  const longestStreak = React.useMemo(
+    () => computeLongestStreak(entries),
+    [entries]
+  );
+  const finalBadge = BADGES.find((b) => b.id === "streak-30");
+
+  const [shareOpen, setShareOpen] = React.useState(false);
+  const [isGenerating, setIsGenerating] = React.useState(false);
+  const journeyRef = React.useRef<HTMLDivElement>(null);
+
+  const handleDownloadImage = async () => {
+    if (!journeyRef.current) return;
+    setIsGenerating(true);
+    try {
+      const fontEmbedCss = `
+        @font-face {
+          font-family: 'Literata';
+          src: url('https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,200..900;1,7..72,200..900&display=swap');
+        }
+      `;
+      const dataUrl = await toPng(journeyRef.current, {
+        cacheBust: true,
+        pixelRatio: 2,
+        fontEmbedCSS: fontEmbedCss,
+      });
+
+      const blob = await (await fetch(dataUrl)).blob();
+      const fileName = "mon-parcours-gratitude-30-jours.png";
+      const file = new File([blob], fileName, { type: "image/png" });
+
+      if (navigator.share && navigator.canShare?.({ files: [file] })) {
+        await navigator.share({
+          title: t("appTitle"),
+          text: t("completionShareHeadline"),
+          files: [file],
+        });
+        onShareBadgeUnlock();
+      } else {
+        const link = document.createElement("a");
+        link.download = fileName;
+        link.href = dataUrl;
+        link.click();
+        onShareBadgeUnlock();
+      }
+      setShareOpen(false);
+    } catch (err: any) {
+      if (err?.name !== "AbortError") {
+        console.error("Failed to generate or share journey image", err);
+        toast({
+          title: t("exportErrorTitle"),
+          description: t("exportErrorDescription"),
+          variant: "destructive",
+        });
+      }
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto flex flex-col items-center text-center gap-8 py-6">
+      {/* Hero : badge final mis en scène */}
+      <motion.div
+        initial={{ opacity: 0, scale: 0.85 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.6, ease: "easeOut" }}
+        className="relative"
+      >
+        <motion.div
+          className="absolute inset-0 rounded-full bg-primary/40"
+          initial={{ scale: 0.8, opacity: 0.6 }}
+          animate={{ scale: 2.2, opacity: 0 }}
+          transition={{ duration: 1.8, ease: "easeOut", repeat: 1, delay: 0.4 }}
+        />
+        <div className="relative p-6 rounded-full bg-primary/15">
+          <Crown className="h-16 w-16 text-primary" />
+        </div>
+      </motion.div>
+
+      <motion.div
+        variants={fadeUp}
+        initial="initial"
+        animate="animate"
+        transition={{ delay: 0.2 }}
+        className="space-y-2"
+      >
+        <h1 className="text-3xl md:text-4xl font-serif font-bold text-foreground">
+          {t("completionHeroTitle")}
+        </h1>
+        <p className="text-muted-foreground text-lg">
+          {t("completionHeroSubtitle")}
+        </p>
+      </motion.div>
+
+      {/* Récap chiffré des 30 jours */}
+      <motion.div
+        variants={fadeUp}
+        initial="initial"
+        animate="animate"
+        transition={{ delay: 0.35 }}
+        className="grid grid-cols-3 gap-4 w-full"
+      >
+        <RecapTile value={entriesCount} label={t("completionRecapEntries")} />
+        <RecapTile
+          value={longestStreak}
+          label={t("completionRecapLongestStreak")}
+        />
+        <RecapTile
+          value={`${Math.min(entriesCount, CHALLENGE_DURATION)}/${CHALLENGE_DURATION}`}
+          label={t("completionRecapDays")}
+        />
+      </motion.div>
+
+      {/* Badge final nommé */}
+      {finalBadge && (
+        <motion.div
+          variants={fadeUp}
+          initial="initial"
+          animate="animate"
+          transition={{ delay: 0.5 }}
+          className="flex items-center gap-3 rounded-full border border-primary/30 bg-primary/5 px-5 py-2"
+        >
+          <Crown className="h-5 w-5 text-primary" />
+          <span className="text-sm">
+            <span className="text-muted-foreground">
+              {t("completionBadgeUnlocked")}{" "}
+            </span>
+            <span className="font-bold text-primary">
+              {t(finalBadge.nameKey)}
+            </span>
+          </span>
+        </motion.div>
+      )}
+
+      {/* CTA newsletter (attribution J30) + amorce app */}
+      {showNewsletter && (
+        <motion.div
+          variants={fadeUp}
+          initial="initial"
+          animate="animate"
+          transition={{ delay: 0.65 }}
+          className="w-full"
+        >
+          <NewsletterSignupCard
+            variant="completion"
+            source="defi-j30"
+            onSubscribed={onNewsletterSubscribed}
+          />
+          <p className="mt-3 text-xs text-muted-foreground">
+            {t("completionAppTeaser")}
+          </p>
+        </motion.div>
+      )}
+
+      {/* Partage du parcours + échappatoires */}
+      <motion.div
+        variants={fadeUp}
+        initial="initial"
+        animate="animate"
+        transition={{ delay: 0.8 }}
+        className="flex flex-col items-center gap-4 w-full"
+      >
+        <Button onClick={() => setShareOpen(true)} className="gap-2">
+          <Share2 className="h-4 w-4" />
+          {t("completionShareCta")}
+        </Button>
+
+        <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm">
+          <Button asChild variant="link" className="text-muted-foreground gap-1 h-auto p-0">
+            <Link href="/journal">
+              <BookOpen className="h-4 w-4" />
+              {t("completionViewJournal")}
+            </Link>
+          </Button>
+          <Button
+            variant="link"
+            onClick={onBackToDashboard}
+            className="text-muted-foreground gap-1 h-auto p-0"
+          >
+            <LayoutDashboard className="h-4 w-4" />
+            {t("completionBackToDashboard")}
+          </Button>
+        </div>
+      </motion.div>
+
+      {/* Dialog d'aperçu + génération image */}
+      <Dialog open={shareOpen} onOpenChange={setShareOpen}>
+        <DialogContent className="max-w-xs">
+          <DialogHeader>
+            <DialogTitle>{t("completionShareDialogTitle")}</DialogTitle>
+            <DialogDescription>
+              {t("completionShareDialogDescription")}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="max-w-[240px] mx-auto w-full">
+            <ShareJourneyCard
+              ref={journeyRef}
+              entriesCount={entriesCount}
+              longestStreak={longestStreak}
+            />
+          </div>
+          <Button onClick={handleDownloadImage} disabled={isGenerating} className="w-full">
+            {isGenerating ? t("newsletterSubmitting") : t("completionShareDownload")}
+          </Button>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function RecapTile({
+  value,
+  label,
+}: {
+  value: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <Card className="bg-card">
+      <CardContent className="p-4 flex flex-col items-center gap-1">
+        <span className="text-2xl md:text-3xl font-bold text-primary">
+          {value}
+        </span>
+        <span className="text-xs text-muted-foreground leading-tight">
+          {label}
+        </span>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/app/NewsletterSignupCard.tsx
+++ b/src/components/app/NewsletterSignupCard.tsx
@@ -25,12 +25,19 @@ interface NewsletterSignupCardProps {
   onSubscribed?: () => void;
   /** Si fourni, affiche un bouton de fermeture (déclencheur non bloquant). */
   onDismiss?: () => void;
+  /**
+   * Label d'attribution supplémentaire (ex. "defi-j30") posé en plus de "défi".
+   * Permet de distinguer la source dans Ghost Admin (pic de complétion vs
+   * mi-parcours). Sans effet sur l'UI.
+   */
+  source?: string;
 }
 
 export function NewsletterSignupCard({
   variant = "inline",
   onSubscribed,
   onDismiss,
+  source,
 }: NewsletterSignupCardProps) {
   const { t } = useLanguage();
   const { toast } = useToast();
@@ -53,7 +60,10 @@ export function NewsletterSignupCard({
     }
 
     setStatus("loading");
-    const result = await subscribeToNewsletter(email);
+    const result = await subscribeToNewsletter(
+      email,
+      source ? ["défi", source] : undefined
+    );
 
     if (result.ok) {
       setStatus("done");

--- a/src/components/app/ShareJourneyCard.tsx
+++ b/src/components/app/ShareJourneyCard.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import * as React from "react";
+import { Crown } from "lucide-react";
+
+import { AppIcon } from "./AppIcon";
+import { useLanguage } from "./LanguageProvider";
+
+interface ShareJourneyCardProps {
+  entriesCount: number;
+  longestStreak: number;
+}
+
+/**
+ * Visuel 9:16 partageable du parcours accompli (fin du défi 30 jours).
+ * Levier d'acquisition organique : chaque image partagée = mini-pub.
+ * Rendu hors-écran puis capturé en PNG par html-to-image (cf. CompletionScreen).
+ */
+export const ShareJourneyCard = React.forwardRef<HTMLDivElement, ShareJourneyCardProps>(
+  ({ entriesCount, longestStreak }, ref) => {
+    const { t } = useLanguage();
+
+    return (
+      <div
+        ref={ref}
+        className="aspect-[9/16] w-full bg-gradient-to-br from-primary/15 via-background to-background border rounded-lg p-6 flex flex-col items-center justify-between shadow-2xl"
+      >
+        <div className="flex items-center gap-2 text-muted-foreground pt-2">
+          <AppIcon className="w-5 h-5" />
+          <p className="font-bold text-sm">{t("appTitle")}</p>
+        </div>
+
+        <div className="flex flex-col items-center text-center gap-4">
+          <div className="p-5 rounded-full bg-primary/15">
+            <Crown className="h-12 w-12 text-primary" />
+          </div>
+          <p className="text-3xl font-serif font-medium text-foreground leading-tight">
+            {t("completionShareHeadline")}
+          </p>
+        </div>
+
+        <div className="w-full flex justify-center gap-8 text-center pb-2">
+          <div>
+            <p className="text-3xl font-bold text-primary">{entriesCount}</p>
+            <p className="text-xs text-muted-foreground uppercase tracking-wide">
+              {entriesCount > 1 ? t("entries") : t("entry")}
+            </p>
+          </div>
+          <div>
+            <p className="text-3xl font-bold text-primary">{longestStreak}</p>
+            <p className="text-xs text-muted-foreground uppercase tracking-wide">
+              {t("completionLongestStreakLabel")}
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+);
+ShareJourneyCard.displayName = "ShareJourneyCard";

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -114,5 +114,20 @@
     "returnWelcomeTitle": "Good to see you back",
     "returnWelcomeDescription": "It's been {days} days. No pressure on the streak — just pick up at day {day}, one entry is enough.",
     "returnWelcomeCta": "Resume",
-    "returnWelcomeDismiss": "Close"
+    "returnWelcomeDismiss": "Close",
+    "completionHeroTitle": "30 days. You did it.",
+    "completionHeroSubtitle": "A month of gratitude, one day at a time. Take a moment to see how far you've come.",
+    "completionRecapEntries": "entries written",
+    "completionRecapLongestStreak": "longest streak",
+    "completionRecapDays": "days completed",
+    "completionLongestStreakLabel": "day streak",
+    "completionBadgeUnlocked": "Badge unlocked:",
+    "completionAppTeaser": "What's next: the well-being app that extends the challenge. The newsletter will keep you posted.",
+    "completionShareCta": "Share my journey",
+    "completionViewJournal": "Back to my journal",
+    "completionBackToDashboard": "Back to my dashboard",
+    "completionShareDialogTitle": "Share your journey",
+    "completionShareDialogDescription": "Here's the image that will be generated to celebrate your 30 days.",
+    "completionShareDownload": "Download image",
+    "completionShareHeadline": "I kept 30 days of gratitude"
 }

--- a/src/lib/locales/fr.json
+++ b/src/lib/locales/fr.json
@@ -114,5 +114,20 @@
     "returnWelcomeTitle": "Content de te revoir",
     "returnWelcomeDescription": "Ça fait {days} jours. Pas de pression pour la série — reprends simplement au jour {day}, une entrée suffit.",
     "returnWelcomeCta": "Reprendre",
-    "returnWelcomeDismiss": "Fermer"
+    "returnWelcomeDismiss": "Fermer",
+    "completionHeroTitle": "30 jours. Tu l'as fait.",
+    "completionHeroSubtitle": "Un mois de gratitude, jour après jour. Prends un instant pour mesurer le chemin.",
+    "completionRecapEntries": "entrées écrites",
+    "completionRecapLongestStreak": "plus longue série",
+    "completionRecapDays": "jours complétés",
+    "completionLongestStreakLabel": "jours de série",
+    "completionBadgeUnlocked": "Badge débloqué :",
+    "completionAppTeaser": "La suite arrive : l'app bien-être qui prolonge le défi. Tu seras prévenu·e par la newsletter.",
+    "completionShareCta": "Partager mon parcours",
+    "completionViewJournal": "Revoir mon journal",
+    "completionBackToDashboard": "Revoir mon tableau de bord",
+    "completionShareDialogTitle": "Partager ton parcours",
+    "completionShareDialogDescription": "Voici l'image qui sera générée pour célébrer tes 30 jours.",
+    "completionShareDownload": "Télécharger l'image",
+    "completionShareHeadline": "J'ai tenu 30 jours de gratitude"
 }

--- a/src/lib/newsletter.ts
+++ b/src/lib/newsletter.ts
@@ -35,7 +35,11 @@ async function getIntegrityToken(): Promise<string | undefined> {
 }
 
 export async function subscribeToNewsletter(
-  rawEmail: string
+  rawEmail: string,
+  // Attribution best-effort : labels posés sur le membre Ghost. Par défaut
+  // ["défi"] (capture mi-parcours) ; l'écran J30 passe ["défi", "defi-j30"]
+  // pour distinguer les inscrits du pic de complétion dans Ghost Admin.
+  labels: string[] = ["défi"]
 ): Promise<SubscribeResult> {
   const email = rawEmail.trim();
   if (!isValidEmail(email)) return { ok: false, reason: "invalid" };
@@ -45,10 +49,9 @@ export async function subscribeToNewsletter(
   const body: Record<string, unknown> = {
     email,
     emailType: "subscribe",
-    // Attribution best-effort : tague la source pour mesurer l'apport du défi
-    // dans Ghost Admin. Ghost peut ignorer ce champ sur l'endpoint public
-    // (à vérifier sur une inscription test) ; aucun effet négatif s'il le strip.
-    labels: ["défi"],
+    // Ghost peut ignorer ce champ sur l'endpoint public (vérifié OK le 9/6/2026
+    // sur une inscription test : le label remonte bien) ; aucun effet négatif.
+    labels,
     name: null,
   };
   if (integrityToken) body.integrityToken = integrityToken;

--- a/src/lib/streak.ts
+++ b/src/lib/streak.ts
@@ -1,0 +1,41 @@
+import type { GratitudeEntry } from "./types";
+
+/**
+ * Calcule la plus longue série de jours calendaires consécutifs à partir des
+ * entrées. `state.streak` ne stocke que la série courante (remise à 0 dès un
+ * jour manqué) — pour le récap J30 on veut le meilleur run de tout le parcours.
+ *
+ * Déterministe, sans dépendance au fuseau au-delà de `toDateString()` (jour
+ * local). Doublons du même jour comptés une seule fois.
+ */
+export function computeLongestStreak(entries: GratitudeEntry[]): number {
+  if (!entries || entries.length === 0) return 0;
+
+  // Jours uniques, normalisés à minuit local, triés croissant.
+  const days = Array.from(
+    new Set(
+      entries
+        .map((e) => new Date(e.date))
+        .filter((d) => !Number.isNaN(d.getTime()))
+        .map((d) => new Date(d.toDateString()).getTime())
+    )
+  ).sort((a, b) => a - b);
+
+  if (days.length === 0) return 0;
+
+  const ONE_DAY = 86400000;
+  let longest = 1;
+  let current = 1;
+
+  for (let i = 1; i < days.length; i++) {
+    const diff = Math.round((days[i] - days[i - 1]) / ONE_DAY);
+    if (diff === 1) {
+      current += 1;
+      if (current > longest) longest = current;
+    } else {
+      current = 1;
+    }
+  }
+
+  return longest;
+}

--- a/tests/unit/lib/streak.test.ts
+++ b/tests/unit/lib/streak.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { computeLongestStreak } from "@/lib/streak";
+import type { GratitudeEntry } from "@/lib/types";
+
+function entry(date: string): GratitudeEntry {
+  return { day: 1, date, text: "x", prompt: "p" };
+}
+
+describe("computeLongestStreak", () => {
+  it("renvoie 0 pour aucune entrée", () => {
+    expect(computeLongestStreak([])).toBe(0);
+  });
+
+  it("renvoie 1 pour une seule entrée", () => {
+    expect(computeLongestStreak([entry("2026-06-01T10:00:00Z")])).toBe(1);
+  });
+
+  it("compte une série de jours consécutifs", () => {
+    const e = [
+      entry("2026-06-01T10:00:00Z"),
+      entry("2026-06-02T10:00:00Z"),
+      entry("2026-06-03T10:00:00Z"),
+    ];
+    expect(computeLongestStreak(e)).toBe(3);
+  });
+
+  it("garde le meilleur run quand il y a un trou", () => {
+    const e = [
+      entry("2026-06-01T10:00:00Z"),
+      entry("2026-06-02T10:00:00Z"),
+      // trou le 3
+      entry("2026-06-04T10:00:00Z"),
+      entry("2026-06-05T10:00:00Z"),
+      entry("2026-06-06T10:00:00Z"),
+    ];
+    expect(computeLongestStreak(e)).toBe(3);
+  });
+
+  it("dédoublonne plusieurs entrées le même jour", () => {
+    const e = [
+      entry("2026-06-01T08:00:00Z"),
+      entry("2026-06-01T20:00:00Z"),
+      entry("2026-06-02T09:00:00Z"),
+    ];
+    expect(computeLongestStreak(e)).toBe(2);
+  });
+
+  it("est insensible à l'ordre des entrées", () => {
+    const e = [
+      entry("2026-06-03T10:00:00Z"),
+      entry("2026-06-01T10:00:00Z"),
+      entry("2026-06-02T10:00:00Z"),
+    ];
+    expect(computeLongestStreak(e)).toBe(3);
+  });
+});


### PR DESCRIPTION
## Quoi
Item **N1** du backlog `diagnostic-defi-v1.md` : écran de complétion J30 célébratoire + partage du parcours.

À J30 (`isChallengeComplete && !showDashboard`), `page.tsx` bascule sur `CompletionScreen` :
- **Hero** : badge Crown `streak-30` (« Maître de la Gratitude » / « Gratitude Master ») + halo qui pulse une fois.
- **Récap chiffré** : entrées · plus longue série (`computeLongestStreak`) · 30/30 jours.
- **CTA newsletter** (attribution `["défi","defi-j30"]`) + teaser app.
- **Partage** : visuel 9:16 (`ShareJourneyCard`) → PNG via `html-to-image`, fix `fontEmbedCSS` (police Literata embarquée).
- **Échappatoire** : « Revoir mon tableau de bord ».

## Validation (preview locale Mac, :9002)
- 24 captures (375/768/1280 × FR/EN × light/dark × Modern/Grimoire) — 0 erreur console, parité FR/EN, mobile 1 colonne.
- Partage-image : PNG valide 480×854, police embarquée.
- Échappatoire dashboard OK.
- `tsc` : 0 nouvelle erreur · `vitest streak` : 6/6.

## Correctif inclus
`6aca59a` — `toast()` sorti de l'updater `setState` (warning React éliminé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
