### PR TITLE
feat(journal): N4 — journal découvrable (lien Header) + fix toast-in-setState

### DIFF
--- a/src/app/journal/page.tsx
+++ b/src/app/journal/page.tsx
@@ -93,21 +93,20 @@ export default function JournalPage() {
   };
 
   const unlockShareBadge = () => {
-    setState(prevState => {
-        if (!prevState || prevState.unlockedBadges.includes('share-1')) {
-            return prevState;
-        }
+    // Garde + effets (toast) HORS de l'updater setState : un updater doit être
+    // pur (rejoué en StrictMode/concurrent → double toast et warning React).
+    if (!state || state.unlockedBadges.includes('share-1')) return;
+    const shareBadge = BADGES.find(b => b.id === 'share-1');
+    if (!shareBadge) return;
 
-        const shareBadge = BADGES.find(b => b.id === 'share-1');
-        if (shareBadge) {
-            const newUnlockedBadges = [...prevState.unlockedBadges, shareBadge.id];
-            toast({
-                title: t('badgeUnlocked'),
-                description: t('badgeUnlockedDescription').replace('{badgeName}', t(shareBadge.nameKey)),
-            });
-            return { ...prevState, unlockedBadges: newUnlockedBadges };
-        }
-        return prevState;
+    setState(prevState =>
+        prevState && !prevState.unlockedBadges.includes('share-1')
+            ? { ...prevState, unlockedBadges: [...prevState.unlockedBadges, shareBadge.id] }
+            : prevState
+    );
+    toast({
+        title: t('badgeUnlocked'),
+        description: t('badgeUnlockedDescription').replace('{badgeName}', t(shareBadge.nameKey)),
     });
   }
   

--- a/src/components/app/Header.tsx
+++ b/src/components/app/Header.tsx
@@ -1,7 +1,8 @@
 
 "use client";
 
-import { Settings, Share2, Upload, Download, Trash2, Palette, Sun, Moon, Star } from "lucide-react";
+import Link from "next/link";
+import { Settings, Share2, Upload, Download, Trash2, Palette, Sun, Moon, Star, BookOpen } from "lucide-react";
 import { ThemeSwitcher } from "./ThemeSwitcher";
 import { LanguageSwitcher } from "./LanguageSwitcher";
 import { useLanguage } from "./LanguageProvider";
@@ -48,6 +49,12 @@ export function Header({ onReset, onShare, onExport, onImport }: HeaderProps) {
         </div>
 
         <div className="flex items-center justify-center md:justify-end gap-2 w-full md:w-1/3">
+            <Button asChild variant="outline" size="icon">
+                <Link href="/journal" aria-label={t('myJournal')}>
+                    <BookOpen className="h-[1.2rem] w-[1.2rem] text-foreground" />
+                    <span className="sr-only">{t('myJournal')}</span>
+                </Link>
+            </Button>
             <Button variant="outline" size="icon" onClick={onShare}>
                 <Share2 className="h-[1.2rem] w-[1.2rem] text-foreground" />
                 <span className="sr-only">{t('share')}</span>


### PR DESCRIPTION
## Quoi
Item **N4** : rend le journal **découvrable** depuis le dashboard + solde une dette de rendu.

- **`Header.tsx`** : bouton `Link href="/journal"` (icône `BookOpen`) en tête du groupe d'actions, avec `aria-label` + `sr-only` (`t('myJournal')`). Avant, le journal n'était atteignable que via l'écran J30 ou un lien profond.
- **`journal/page.tsx`** : `unlockShareBadge` corrigé — garde + `toast()` sortis de l'updater `setState` (updater pur, plus de warning React « Cannot update a component while rendering a different component », ni de double-toast en StrictMode). Même correctif que celui déjà appliqué à `page.tsx` pour l'écran J30.

## Validation (preview locale Mac, :9002)
- Captures Header (375/768/1280 × FR/EN × light/dark × Modern/Grimoire) — bouton journal présent et cohérent, mobile sur une seule rangée, 0 erreur console.
- **Navigation** : clic → `/journal`, page rendue.
- **Fix toast-in-setState** : partage d'une entrée → badge `share-1` débloqué, **0 warning React**.
- `tsc --noEmit` : 0 erreur sur les fichiers de la branche.
- `vitest` : 11 échecs / 17 = dette pré-existante connue (Radix/dropdown), aucune régression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
